### PR TITLE
Django 1.10 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Features
 
 -  Requirements
 
-   -  Django >= 1.7
+   -  Django >= 1.8
    -  Python 2.7, 3.4, 3.5
 
 Feature examples

--- a/bungiesearch/__init__.py
+++ b/bungiesearch/__init__.py
@@ -192,7 +192,15 @@ class Bungiesearch(Search):
                     desired_fields = instance._only
 
                 if desired_fields: # Prevents setting the database fetch to __fields but not having specified any field to elasticsearch.
-                    items = items.only(*[field for field in model_obj._meta.get_all_field_names() if field in desired_fields])
+                    items = items.only(
+                        *[field.name
+                          for field in model_obj._meta.get_fields()
+                          # For complete backwards compatibility, you may want to exclude
+                          # GenericForeignKey from the results.
+                          if field.name in desired_fields and \
+                             not (field.many_to_one and field.related_model is None)
+                         ]
+                    )
             # Let's reposition each item in the results and set the _searchmeta meta information.
             for item in items:
                 pos, meta = found_results['{}.{}.{}'.format(index_name, model_name, item.pk)]

--- a/bungiesearch/management/commands/_utils.py
+++ b/bungiesearch/management/commands/_utils.py
@@ -1,0 +1,25 @@
+
+
+def add_arguments(obj, parser):
+    parser.add_argument(
+        '--noinput',
+        action='store_false',
+        dest='interactive',
+        default=True,
+        help='If provided, no prompts will be issued to the user and the data will be wiped out'
+    )
+    parser.add_argument(
+        '--guilty-as-charged',
+        action='store_true',
+        dest='confirmed',
+        default=False,
+        help='Flag needed to confirm the clear index.'
+    )
+    parser.add_argument(
+        '--timeout',
+        action='store',
+        dest='timeout',
+        default=None,
+        type=int,
+        help='Specify the timeout in seconds for each operation.'
+    )

--- a/bungiesearch/management/commands/clear_index.py
+++ b/bungiesearch/management/commands/clear_index.py
@@ -4,33 +4,12 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.utils import six
 
+from ._utils import add_arguments
+
 
 class Command(BaseCommand):
     help = 'Clears the search index of its contents.'
-
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--noinput',
-            action='store_false',
-            dest='interactive',
-            default=True,
-            help='If provided, no prompts will be issued to the user and the data will be wiped out'
-        )
-        parser.add_argument(
-            '--guilty-as-charged',
-            action='store_true',
-            dest='confirmed',
-            default=False,
-            help='Flag needed to confirm the clear index.'
-        )
-        parser.add_argument(
-            '--timeout',
-            action='store',
-            dest='timeout',
-            default=None,
-            type=int,
-            help='Specify the timeout in seconds for each operation.'
-        )
+    add_arguments = add_arguments
 
     def handle(self, **options):
         if options.get('interactive', True):

--- a/bungiesearch/management/commands/clear_index.py
+++ b/bungiesearch/management/commands/clear_index.py
@@ -1,5 +1,4 @@
 import sys
-from optparse import make_option
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
@@ -9,24 +8,29 @@ from django.utils import six
 class Command(BaseCommand):
     help = 'Clears the search index of its contents.'
 
-    option_list = BaseCommand.option_list + (
-        make_option('--noinput',
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--noinput',
             action='store_false',
             dest='interactive',
             default=True,
-            help='If provided, no prompts will be issued to the user and the data will be wiped out'),
-        make_option('--guilty-as-charged',
+            help='If provided, no prompts will be issued to the user and the data will be wiped out'
+        )
+        parser.add_argument(
+            '--guilty-as-charged',
             action='store_true',
             dest='confirmed',
             default=False,
-            help='Flag needed to confirm the clear index.'),
-        make_option('--timeout',
+            help='Flag needed to confirm the clear index.'
+        )
+        parser.add_argument(
+            '--timeout',
             action='store',
             dest='timeout',
             default=None,
-            type='int',
-            help='Specify the timeout in seconds for each operation.')
-       )
+            type=int,
+            help='Specify the timeout in seconds for each operation.'
+        )
 
     def handle(self, **options):
         if options.get('interactive', True):

--- a/bungiesearch/management/commands/rebuild_index.py
+++ b/bungiesearch/management/commands/rebuild_index.py
@@ -1,12 +1,12 @@
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
-from .clear_index import Command as ClearCommand
+from ._utils import add_arguments
 
 
 class Command(BaseCommand):
     help = "Rebuilds the search index by clearing the search index and then performing an update."
-    option_list = set(BaseCommand.option_list + ClearCommand.option_list)
+    add_arguments = add_arguments
 
     def handle(self, **options):
         call_command('clear_index', **options)

--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -68,35 +68,35 @@ class Command(BaseCommand):
             action='store',
             dest='bulk_size',
             default=100,
-            type='int',
+            type=int,
             help='Specify the number of items to be updated together.')
         parser.add_argument(
             '--num-docs',
             action='store',
             dest='num_docs',
             default=-1,
-            type='int',
+            type=int,
             help='Specify the maximum number of items to be indexed. By default will index the whole model.')
         parser.add_argument(
             '--start',
             action='store',
             dest='start_date',
             default=None,
-            type='str',
+            type=str,
             help='Specify the start date and time of documents to be indexed.')
         parser.add_argument(
             '--end',
             action='store',
             dest='end_date',
             default=None,
-            type='str',
+            type=str,
             help='Specify the end date and time of documents to be indexed.')
         parser.add_argument(
             '--timeout',
             action='store',
             dest='timeout',
             default=None,
-            type='int',
+            type=int,
             help='Specify the timeout in seconds for each operation.')
 
     def handle(self, *args, **options):

--- a/bungiesearch/management/commands/search_index.py
+++ b/bungiesearch/management/commands/search_index.py
@@ -1,6 +1,5 @@
 import logging
 from collections import defaultdict
-from optparse import make_option
 
 from six import iteritems
 
@@ -14,78 +13,91 @@ class Command(BaseCommand):
     args = ''
     help = 'Manage search index.'
 
-    option_list = BaseCommand.option_list + (
-        make_option('--create',
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--create',
             action='store_const',
             dest='action',
             const='create',
-            help='Create the index specified in the settings with the mapping generating from the search indices.'),
-        make_option('--update',
+            help='Create the index specified in the settings with the mapping generating from the search indices.'
+        )
+        parser.add_argument(
+            '--update',
             action='store_const',
             dest='action',
             const='update',
-            help='Update the index specified in the settings with the mapping generating from the search indices.'),
-        make_option('--update-mapping',
+            help='Update the index specified in the settings with the mapping generating from the search indices.')
+        parser.add_argument(
+            '--update-mapping',
             action='store_const',
             dest='action',
             const='update-mapping',
-            help='Update the mapping of specified models (or all models) on the index specified in the settings.'),
-        make_option('--delete',
+            help='Update the mapping of specified models (or all models) on the index specified in the settings.')
+        parser.add_argument(
+            '--delete',
             action='store_const',
             dest='action',
             const='delete',
-            help='Delete the index specified in the settings. Requires the "--guilty-as-charged" flag.'),
-        make_option('--delete-mapping',
+            help='Delete the index specified in the settings. Requires the "--guilty-as-charged" flag.')
+        parser.add_argument(
+            '--delete-mapping',
             action='store_const',
             dest='action',
             const='delete-mapping',
-            help='Delete the mapping of specified models (or all models) on the index specified in the settings. Requires the "--guilty-as-charged" flag.'),
-        make_option('--guilty-as-charged',
+            help='Delete the mapping of specified models (or all models) on the index specified in the settings. Requires the "--guilty-as-charged" flag.')
+        parser.add_argument(
+            '--guilty-as-charged',
             action='store_true',
             dest='confirmed',
             default=False,
-            help='Flag needed to delete an index.'),
-        make_option('--models',
+            help='Flag needed to delete an index.')
+        parser.add_argument(
+            '--models',
             action='store',
             dest='models',
             default=None,
-            help='Models to be updated, separated by commas. If none are specified, then all models defined in the index will be updated.'),
-        make_option('--index',
+            help='Models to be updated, separated by commas. If none are specified, then all models defined in the index will be updated.')
+        parser.add_argument(
+            '--index',
             action='store',
             dest='index',
             default=None,
-            help='Specify the index for which to apply the action, as defined in BUNGIESEARCH.INDEXES of settings. Defaults to using all indices.'),
-        make_option('--bulk-size',
+            help='Specify the index for which to apply the action, as defined in BUNGIESEARCH.INDEXES of settings. Defaults to using all indices.')
+        parser.add_argument(
+            '--bulk-size',
             action='store',
             dest='bulk_size',
             default=100,
             type='int',
-            help='Specify the number of items to be updated together.'),
-        make_option('--num-docs',
+            help='Specify the number of items to be updated together.')
+        parser.add_argument(
+            '--num-docs',
             action='store',
             dest='num_docs',
             default=-1,
             type='int',
-            help='Specify the maximum number of items to be indexed. By default will index the whole model.'),
-        make_option('--start',
+            help='Specify the maximum number of items to be indexed. By default will index the whole model.')
+        parser.add_argument(
+            '--start',
             action='store',
             dest='start_date',
             default=None,
             type='str',
-            help='Specify the start date and time of documents to be indexed.'),
-        make_option('--end',
+            help='Specify the start date and time of documents to be indexed.')
+        parser.add_argument(
+            '--end',
             action='store',
             dest='end_date',
             default=None,
             type='str',
-            help='Specify the end date and time of documents to be indexed.'),
-        make_option('--timeout',
+            help='Specify the end date and time of documents to be indexed.')
+        parser.add_argument(
+            '--timeout',
             action='store',
             dest='timeout',
             default=None,
             type='int',
             help='Specify the timeout in seconds for each operation.')
-        )
 
     def handle(self, *args, **options):
         del args

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os.path import dirname, join
 
 from setuptools import find_packages, setup
 
-VERSION = (1, 3, 0, 3)
+VERSION = (1, 3, 0, 5)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(join(dirname(__file__), 'README.rst')) as f:
 
 
 install_requires = [
-    'django>=1.7',
+    'django>=1.8',
     'elasticsearch-dsl>=0.0.4',
     'elasticsearch>=1.0.0,<=2.1.0'
     'python-dateutil',

--- a/tests/core/test_bungiesearch.py
+++ b/tests/core/test_bungiesearch.py
@@ -291,8 +291,7 @@ class CoreTestCase(TestCase):
         db_item = NoUpdatedField.objects.get(pk=1)
         src_item = NoUpdatedField.objects.search.query('match', title='My title')[0]
         self.assertEqual(src_item.id, db_item.id, 'Searching for the object did not return the expected object id.')
-        self.assertTrue(src_item._meta.proxy, 'Was expecting a proxy model after fetching item.')
-        self.assertEqual(src_item._meta.proxy_for_model, NoUpdatedField, 'Proxy for model of search item is not "NoUpdatedField".')
+        self.assertEqual(src_item.get_deferred_fields(), {'description'})
 
     def test_concat_queries(self):
         items = Article.objects.bsearch_title_search('title')[::False] + NoUpdatedField.objects.search.query('match', title='My title')[::False]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,6 +28,25 @@ DATABASES = {
     }
 }
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
 BUNGIESEARCH = {
     'URLS': [os.getenv('ELASTIC_SEARCH_URL', 'localhost')],
     'ES_SETTINGS': {


### PR DESCRIPTION
@BetterWorks/goals 
@terite 

Created a placeholder v1.3.0.3 branch which holds our existing release that we use, not sure why that's not in a branch atm. Created another v1.3.0.5 to hold this release, not sure why theres a 1.3.0.4 tag, but didn't want to step on anything.

Cherrypicked all the changes from the original repo, added a test change since excluded fields are handled differently in django 1.10